### PR TITLE
Fix stale range filter parsing

### DIFF
--- a/app/forms/search_subscription_form.rb
+++ b/app/forms/search_subscription_form.rb
@@ -8,8 +8,8 @@ class SearchSubscriptionForm
   attribute :filter_column, :string
   attribute :text_filter_value, :string
   attribute :text_filter_pattern, :string
-  attribute :date_filter_start, :date
-  attribute :date_filter_end, :date
+  attribute :date_filter_start, :string
+  attribute :date_filter_end, :string
   attribute :date_filter_pattern, :string
   attribute :first_column, :string
   attribute :first_direction, :string
@@ -50,8 +50,8 @@ class SearchSubscriptionForm
   def build_search_query
     if text_filter?
       filter_by_text
-    elsif date_filter?
-      filter_by_date
+    elsif range_filter?
+      filter_by_range
     else
       ->(scope) { scope.where(Subscription.arel_table[filter_column.to_sym].matches("%#{ActiveRecord::Base.sanitize_sql_like(text_filter_value)}%")) }
     end
@@ -71,17 +71,28 @@ class SearchSubscriptionForm
     end
   end
 
-  def filter_by_date
-    if date_filter_pattern == "exact"
-      ->(scope) { scope.where(Subscription.arel_table[filter_column.to_sym].eq(date_filter_start)) }
-    elsif date_filter_pattern == "before"
-      ->(scope) { scope.where(Subscription.arel_table[filter_column.to_sym].lt(date_filter_start)) }
-    elsif date_filter_pattern == "after"
-      ->(scope) { scope.where(Subscription.arel_table[filter_column.to_sym].gt(date_filter_start)) }
-    elsif date_filter_pattern == "between"
-      ->(scope) { scope.where(Subscription.arel_table[filter_column.to_sym].gteq(date_filter_start).and(Subscription.arel_table[filter_column.to_sym].lteq(date_filter_end))) }
+  def filter_by_range
+    column = Subscription.arel_table[filter_column.to_sym]
+    start_value = parse_range_value(date_filter_start, :start)
+    end_value = if date_filter_pattern == "between"
+      parse_range_value(date_filter_end, :end)
+    end
+
+    return ->(scope) { scope.none } if start_value.nil?
+
+    case date_filter_pattern
+    when "exact"
+      ->(scope) { scope.where(column.eq(start_value)) }
+    when "before"
+      ->(scope) { scope.where(column.lt(start_value)) }
+    when "after"
+      ->(scope) { scope.where(column.gt(start_value)) }
+    when "between"
+      return ->(scope) { scope.none } if end_value.nil?
+
+      ->(scope) { scope.where(column.gteq(start_value).and(column.lteq(end_value))) }
     else
-      ->(scope) { scope.where(Subscription.arel_table[filter_column.to_sym].eq(date_filter_start)) }
+      ->(scope) { scope.where(column.eq(start_value)) }
     end
   end
 
@@ -94,8 +105,8 @@ class SearchSubscriptionForm
     column_type == :string
   end
 
-  def date_filter?
-    column_type == :date || column_type == :decimal
+  def range_filter?
+    column_type.in?([:date, :decimal, :integer])
   end
 
   def column_type
@@ -118,8 +129,12 @@ class SearchSubscriptionForm
 
     if text_filter?
       text_filter_value.present?
-    elsif date_filter?
-      date_filter_start.present?
+    elsif range_filter?
+      if date_filter_pattern == "between"
+        date_filter_start.present? && date_filter_end.present?
+      else
+        date_filter_start.present?
+      end
     else
       text_filter_value.present?
     end
@@ -128,5 +143,32 @@ class SearchSubscriptionForm
   def sort_params_present?
     first_column.present? && first_direction.present? ||
     second_column.present? && second_direction.present?
+  end
+
+  def parse_range_value(value, _position)
+    return if value.blank?
+
+    result = cast_range_value(value)
+    result
+  rescue ArgumentError, TypeError
+    errors.add(:base, "無効な検索値です") unless errors[:base].include?("無効な検索値です")
+    nil
+  end
+
+  def cast_range_value(value)
+    type = attribute_type
+    return value if type.nil?
+
+    type.deserialize(value).tap do |casted|
+      if casted.nil?
+        errors.add(:base, "無効な検索値です") unless errors[:base].include?("無効な検索値です")
+      end
+    end
+  end
+
+  def attribute_type
+    return if filter_column.blank?
+
+    Subscription.type_for_attribute(filter_column)
   end
 end

--- a/app/javascript/subscription_filter.js
+++ b/app/javascript/subscription_filter.js
@@ -1,71 +1,211 @@
 import jQuery from "jquery";
 window.$ = jQuery;
 
-
-// フィルターの初期化と設定を行う関数
 function initializeFilters() {
-  // 既存イベントを解除（重複防止）
-  $(document).off("change", "select[name='q[filter_column]']");
-  $(document).off("change", "select[name='q[date_filter_pattern]']");
-  $(document).off("click", "#add_filter_button");
-  $(document).off("click", "#open_filter_box");
-  $(document).off("click", "#open_sort_box");
-  $(document).off("click", "#add_sort_button");
+  const $document = $(document);
+  const $filterColumnSelect = $("select[name='q[filter_column]']");
+  const $rangePatternContainer = $("#range_filter_pattern_container");
+  const $rangePatternSelect = $("select[name='q[date_filter_pattern]']");
+  const $rangeFields = $("#range_filter_fields");
+  const $rangeEndField = $("#range_filter_end_field");
+  const $rangeStartInput = $("#range_filter_start_input");
+  const $rangeEndInput = $("#range_filter_end_input");
+  const $rangeStartLabel = $("#range_filter_start_label");
+  const $rangeEndLabel = $("#range_filter_end_label");
+  const $textFilterPattern = $("#text_filter_pattern");
+  const $textFilterFields = $("#text_filter_fields");
+  const $textFilterInput = $textFilterFields.find("input[name='q[text_filter_value]']");
+  const defaultStartLabel = $rangeStartLabel.text();
+  const defaultEndLabel = $rangeEndLabel.text();
 
-  // イベント委譲でバインド
-  $(document).on("change", "select[name='q[filter_column]']", function() {
+  $document.off("change", "select[name='q[filter_column]']");
+  $document.off("change", "select[name='q[date_filter_pattern]']");
+  $document.off("click", "#add_filter_button");
+  $document.off("click", "#open_filter_box");
+  $document.off("click", "#open_sort_box");
+  $document.off("click", "#add_sort_button");
+
+  function disableRangeInputs() {
+    $rangeStartInput.prop("disabled", true);
+    $rangeEndInput.prop("disabled", true);
+  }
+
+  function enableRangeInputs() {
+    $rangeStartInput.prop("disabled", false);
+    if ($rangeEndField.is(":visible")) {
+      $rangeEndInput.prop("disabled", false);
+    }
+  }
+
+  function resetRangeInputAttributes() {
+    $rangeStartInput.removeAttr("type").attr("type", "text");
+    $rangeEndInput.removeAttr("type").attr("type", "text");
+    [ $rangeStartInput, $rangeEndInput ].forEach(($input) => {
+      $input.removeAttr("step");
+      $input.removeAttr("min");
+      $input.removeAttr("max");
+    });
+    $rangeStartLabel.text(defaultStartLabel);
+    $rangeEndLabel.text(defaultEndLabel);
+  }
+
+  function hideTextFields() {
+    $textFilterPattern.hide();
+    $textFilterFields.hide();
+    $textFilterInput.prop("disabled", true);
+  }
+
+  function showTextFields() {
+    $textFilterPattern.show();
+    $textFilterFields.show();
+    $textFilterInput.prop("disabled", false);
+  }
+
+  function hideRangeFields() {
+    $rangePatternContainer.hide();
+    $rangeFields.hide();
+    $rangeEndField.hide();
+    disableRangeInputs();
+  }
+
+  function updateRangeFieldVisibility(pattern) {
+    if (pattern === "between") {
+      $rangeEndField.show();
+      $rangeEndInput.prop("disabled", false);
+    } else {
+      $rangeEndField.hide();
+      $rangeEndInput.prop("disabled", true);
+    }
+  }
+
+  function readSelectedConfig() {
+    const $selectedOption = $filterColumnSelect.find("option:selected");
+    if ($selectedOption.length === 0) {
+      return null;
+    }
+
+    const type = $selectedOption.data("filterType");
+    if (!type) {
+      return null;
+    }
+
+    return {
+      type,
+      step: $selectedOption.data("rangeStep"),
+      min: $selectedOption.data("rangeMin"),
+      max: $selectedOption.data("rangeMax"),
+      startLabel: $selectedOption.data("rangeStartLabel"),
+      endLabel: $selectedOption.data("rangeEndLabel")
+    };
+  }
+
+  function configureRangeFields(config) {
+    hideTextFields();
+    $rangePatternContainer.show();
+    $rangeFields.show();
+    $rangePatternSelect.prop("disabled", false);
+
+    resetRangeInputAttributes();
+
+    const type = config.type;
+    if (type === "date") {
+      $rangeStartInput.attr("type", "date");
+      $rangeEndInput.attr("type", "date");
+    } else if (type === "number") {
+      $rangeStartInput.attr("type", "number");
+      $rangeEndInput.attr("type", "number");
+      if (config.step) {
+        $rangeStartInput.attr("step", config.step);
+        $rangeEndInput.attr("step", config.step);
+      }
+      if (config.min) {
+        $rangeStartInput.attr("min", config.min);
+        $rangeEndInput.attr("min", config.min);
+      }
+      if (config.max) {
+        $rangeStartInput.attr("max", config.max);
+        $rangeEndInput.attr("max", config.max);
+      }
+    }
+
+    if (config.start_label) {
+      $rangeStartLabel.text(config.start_label);
+    }
+    if (config.end_label) {
+      $rangeEndLabel.text(config.end_label);
+    }
+
+    updateRangeFieldVisibility($rangePatternSelect.val());
+    enableRangeInputs();
+  }
+
+  function configureTextFields() {
+    showTextFields();
+    hideRangeFields();
+    resetRangeInputAttributes();
+    $rangePatternSelect.prop("disabled", true);
+  }
+
+  function resetFilters() {
+    hideTextFields();
+    hideRangeFields();
+    resetRangeInputAttributes();
+    $rangePatternSelect.prop("disabled", true);
+  }
+
+  $document.on("change", "select[name='q[filter_column]']", function() {
     const selectedColumn = $(this).val();
-    if (selectedColumn === "name" || selectedColumn === "plan") {
-      $("#text_filter_pattern").show();
-      $("#text_filter_fields").show();
-      $("#date_filter_fields").hide();
-    } else if (
-        selectedColumn === "price" ||
-        selectedColumn === "start_date" ||
-        selectedColumn === "end_date" ||
-        selectedColumn === "billing_day_of_month"
-    ) {
-      $("#text_filter_pattern").hide();
-      $("#text_filter_fields").hide();
-      $("#date_filter_fields").show();
-      $("#q_text_filter_patter").show();
+    const config = readSelectedConfig();
+
+    if (!selectedColumn || !config) {
+      resetFilters();
+      return;
+    }
+
+    if (config.type === "text") {
+      configureTextFields();
     } else {
-      $("#text_filter_fields").hide();
-      $("#date_filter_fields").hide();
+      configureRangeFields({
+        type: config.type,
+        step: config.step,
+        min: config.min,
+        max: config.max,
+        start_label: config.startLabel,
+        end_label: config.endLabel
+      });
     }
   });
 
-  $(document).on("change", "select[name='q[date_filter_pattern]']", function() {
+  $document.on("change", "select[name='q[date_filter_pattern]']", function() {
     const selectedPattern = $(this).val();
-    if (selectedPattern === "between") {
-      $("#date_filter_end_field").show();
-    } else {
-      $("#date_filter_end_field").hide();
-    }
+    updateRangeFieldVisibility(selectedPattern);
+    enableRangeInputs();
   });
 
-  $(document).on("click", "#add_filter_button", function() {
+  $document.on("click", "#add_filter_button", function() {
     $("#filter_box").hide();
   });
 
-  $(document).on("click", "#open_filter_box", function() {
+  $document.on("click", "#open_filter_box", function() {
     $("#filter_box").toggle();
   });
 
-  $(document).on("click", "#open_sort_box", function() {
+  $document.on("click", "#open_sort_box", function() {
     $("#sort_box").toggle();
   });
 
-  $(document).on("click", "#add_sort_button", function() {
+  $document.on("click", "#add_sort_button", function() {
     $("#sort_box").hide();
   });
+
+  if ($filterColumnSelect.length > 0) {
+    $filterColumnSelect.trigger("change");
+  }
 }
 
-// Turboイベントで初期化
 document.addEventListener("turbo:load", initializeFilters);
 document.addEventListener("turbo:render", initializeFilters);
 document.addEventListener("turbo:frame-render", initializeFilters);
 document.addEventListener("turbo:submit-end", initializeFilters);
 
-// ページ初回ロード時も初期化
 $(document).ready(initializeFilters);

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -14,13 +14,39 @@
                 <div class="text-start">
                   <%= f.label :filter_column, "フィルター", class: "form-label" %>
                 </div>
-                <%= f.select :filter_column, [["選択してください", ""],
-                                              [Subscription.human_attribute_name(:name), "name"],
-                                              [Subscription.human_attribute_name(:plan), "plan"],
-                                              [Subscription.human_attribute_name(:price), "price"],
-                                              [Subscription.human_attribute_name(:start_date), "start_date"],
-                                              [Subscription.human_attribute_name(:end_date), "end_date"],
-                                              [Subscription.human_attribute_name(:billing_day_of_month), "billing_day_of_month"]], {},
+                <% filter_column_options = [
+                  ["選択してください", ""],
+                  [Subscription.human_attribute_name(:name), "name", { data: { filter_type: "text" } }],
+                  [Subscription.human_attribute_name(:plan), "plan", { data: { filter_type: "text" } }],
+                  [Subscription.human_attribute_name(:price), "price", { data: {
+                    filter_type: "number",
+                    range_start_label: Subscription.human_attribute_name(:price),
+                    range_end_label: Subscription.human_attribute_name(:price),
+                    range_step: "0.01",
+                    range_min: "0"
+                  } }],
+                  [Subscription.human_attribute_name(:start_date), "start_date", { data: {
+                    filter_type: "date",
+                    range_start_label: Subscription.human_attribute_name(:start_date),
+                    range_end_label: Subscription.human_attribute_name(:end_date)
+                  } }],
+                  [Subscription.human_attribute_name(:end_date), "end_date", { data: {
+                    filter_type: "date",
+                    range_start_label: Subscription.human_attribute_name(:end_date),
+                    range_end_label: Subscription.human_attribute_name(:end_date)
+                  } }],
+                  [Subscription.human_attribute_name(:billing_day_of_month), "billing_day_of_month", { data: {
+                    filter_type: "number",
+                    range_start_label: Subscription.human_attribute_name(:billing_day_of_month),
+                    range_end_label: Subscription.human_attribute_name(:billing_day_of_month),
+                    range_step: "1",
+                    range_min: "1",
+                    range_max: "31"
+                  } }]
+                ] %>
+                <%= f.select :filter_column,
+                             options_for_select(filter_column_options, f.object.filter_column),
+                             {},
                              class: "form-select" %>
               </div>
               <div class="d-flex align-items-end">
@@ -35,7 +61,7 @@
                 </div>
               </div>
               <div class="d-flex align-items-end">
-                <div id="date_filter_fields" style="display: none;">
+                <div id="range_filter_pattern_container" style="display: none;">
                   <%= f.select :date_filter_pattern, [["完全一致", "exact"],
                                                       ["指定日より前", "before"],
                                                       ["指定日より後", "after"],
@@ -45,20 +71,20 @@
                 </div>
               </div>
             </div>
-            <div id="q_text_filter_patter" style="display: none;" class="mb-2">
+            <div id="range_filter_fields" style="display: none;" class="mb-2">
               <div class="d-flex flex-column text-start gap-1 mb-1">
-                <%= f.label :date_filter_start, Subscription.human_attribute_name(:start_date), class: "form-label" %>
-                <%= f.date_field :date_filter_start, class: "form-control" %>
+                <%= f.label :date_filter_start, Subscription.human_attribute_name(:start_date), class: "form-label", id: "range_filter_start_label" %>
+                <%= f.text_field :date_filter_start, class: "form-control", id: "range_filter_start_input", disabled: true %>
               </div>
-              <div id="date_filter_end_field" style="display: none;">
+              <div id="range_filter_end_field" style="display: none;">
                 <div class="d-flex flex-column text-start gap-1">
-                  <%= f.label :date_filter_end, Subscription.human_attribute_name(:end_date), class: "form-label" %>
-                  <%= f.date_field :date_filter_end, class: "form-control" %>
+                  <%= f.label :date_filter_end, Subscription.human_attribute_name(:end_date), class: "form-label", id: "range_filter_end_label" %>
+                  <%= f.text_field :date_filter_end, class: "form-control", id: "range_filter_end_input", disabled: true %>
                 </div>
               </div>
             </div>
             <div id="text_filter_fields" style="display: none;" class="mb-3">
-              <%= f.search_field :text_filter_value, placeholder: "検索値を入力してください", class: "w-100 form-control" %>
+              <%= f.search_field :text_filter_value, placeholder: "検索値を入力してください", class: "w-100 form-control", disabled: true %>
             </div>
             <%= f.submit "フィルターを追加", class: "btn btn-outline-secondary w-100", id: "add_filter_button" %>
           </div>

--- a/spec/models/search_subscription_form_spec.rb
+++ b/spec/models/search_subscription_form_spec.rb
@@ -90,6 +90,38 @@ RSpec.describe SearchSubscriptionForm, type: :model do
       expect(subscriptions.first.price).to eq 90
     end
 
+    it "returns subscriptions when billing_day_of_month matches the numeric filter" do
+      FactoryBot.create(:subscription, user: user, billing_day_of_month: 5)
+      FactoryBot.create(:subscription, user: user, billing_day_of_month: 15)
+      FactoryBot.create(:subscription, user: user, billing_day_of_month: 28)
+
+      form = FactoryBot.build(:search_subscription_form,
+                              current_user: user,
+                              filter_column: "billing_day_of_month",
+                              date_filter_start: "15",
+                              date_filter_pattern: "exact")
+
+      subscriptions = form.search_subscriptions
+
+      expect(subscriptions.length).to eq 1
+      expect(subscriptions.first.billing_day_of_month).to eq 15
+    end
+
+    it "adds an error when range filter value cannot be parsed" do
+      FactoryBot.create(:subscription, user: user, billing_day_of_month: 10)
+
+      form = FactoryBot.build(:search_subscription_form,
+                              current_user: user,
+                              filter_column: "billing_day_of_month",
+                              date_filter_start: "invalid",
+                              date_filter_pattern: "exact")
+
+      subscriptions = form.search_subscriptions
+
+      expect(subscriptions).to be_empty
+      expect(form.errors[:base]).to include "無効な検索値です"
+    end
+
     it "returns subscriptions when name contains search term (partial match)" do
       FactoryBot.create(:subscription, user: user, name: "Netflix Premium")
       FactoryBot.create(:subscription, user: user, name: "Netflix Basic")


### PR DESCRIPTION
## Summary
- stop caching parsed range filter values so updated inputs are re-cast on every search
- only parse the range end when the between pattern is selected to avoid unnecessary errors

## Testing
- `bundle exec rspec` *(fails: bundler could not find the rspec executable before dependencies were installed)*
- `bundle install` *(fails: 403 Forbidden when reaching rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68f324cb6b748323b3dc0ba322ad9cf6